### PR TITLE
Using latest version of Result

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "antitypical/Result" ~> 3.0
+github "antitypical/Result"


### PR DESCRIPTION
This ensures compatibility with Swift 4. The default compiler version is now set to Swift 4 instead of Swift 3